### PR TITLE
[DOC] add mention to mandatory dependencies installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## Available Scripts
 
-In the project directory, you can run:
+In the project directory, start by running `npm install` to retrieve mandatory dependencies, then you can run:
 
 ### `npm start`
 


### PR DESCRIPTION
If this step is skipped, it can lead to errors such as "react-scripts : not found"