### PR TITLE
Allow to pass custom backend address at build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
+:information_source: By default, the project is meant to be run and opened on same host than [the backend](https://github.com/ratchet34/blindtest-reforged-back). If your use case expects your pages to be opened by browsers on different hosts than the one hosting the backend, you need to specify the backend address  when building the front end. To do so, export the `REACT_APP_WEBSOCKET_SERVER_ADDRESS` as en environment variable when building your application. For example : 
+```
+REACT_APP_WEBSOCKET_SERVER_ADDRESS=ws://192.168.1.254:6969 npm start
+REACT_APP_WEBSOCKET_SERVER_ADDRESS=ws://sunflower.local:6969 npm run build
+```
+
+
+
 ### `npm test`
 
 Launches the test runner in the interactive watch mode.\

--- a/src/Components/Mainframe.jsx
+++ b/src/Components/Mainframe.jsx
@@ -12,7 +12,8 @@ function Mainframe() {
   const [doneItems, setDoneItems] = useState([]);
   const [currItem, setCurrItem] = useState(null);
   const [nextItem, setNextItem] = useState(null);
-  const { sendMessage, lastMessage, readyState } = useWebSocket('ws://localhost:6969', {
+  const websocketServerUrl = process.env.REACT_APP_WEBSOCKET_SERVER_ADDRESS ? process.env.REACT_APP_WEBSOCKET_SERVER_ADDRESS : 'ws://localhost:6969';
+  const { sendMessage, lastMessage, readyState } = useWebSocket(websocketServerUrl, {
     shouldReconnect: () => true,
   });
 


### PR DESCRIPTION
Constaté en faisant tourner le blindtest sur RPI et en lançant le blindtest sur un navigateur sur mon PC : la page n'arrive pas à se connecter au serveur de websocket car son addresse est hardcodée dans le front (`ws://localhost:6969)
=> proposition d'ajout d'une variable d'environnement au build pour pouvoir changer l'addresse de l'hôte qui héberge le backend (ex : la RPI) 