### PR TITLE
css: make teams button more readable with buzzers count >= 5

### DIFF
--- a/src/Components/buzzer.css
+++ b/src/Components/buzzer.css
@@ -1,6 +1,6 @@
 .buzzer {
-  width: 20%;
-  max-width: 12em;
+  width: 18%;
+  max-width: 18%;
   height: 100%;
   border-radius: 1em;
   border: 1px solid black;
@@ -13,7 +13,7 @@
 
 .buzzer > p {
   font-weight: bold;
-  font-size: x-large;
+  font-size: large;
   margin: 0;
 }
 
@@ -43,6 +43,8 @@
   justify-content: space-between;
   width: 60%;
   margin: auto;
+  font-size: x-large;
+  font-weight: bold;
 }
 
 .buzzer > .score-btns > .button {

--- a/src/Components/mainframe.css
+++ b/src/Components/mainframe.css
@@ -10,12 +10,14 @@
 #buzzer-container {
   position: absolute;
   bottom: 0;
-  left: 10%;
-  width: 80%;
+  left: 0%;
+  width: 100%;
   height: 20%;
   max-height: 8em;
   padding-bottom: 1em;
   display: flex;
-  gap: 5%;
+  flex-wrap: wrap;
+  gap: 1%;
   justify-content: center;
+  top: 80%;
 }


### PR DESCRIPTION
Make sure that buzzers can span on two lines. Decrease teams name size, increase score size.
Tested on a FHD screen and a FHD+ screen
Still not handling page zoom or very long team names, but it is at least readable with a reasonable default browser configuration
![image](https://github.com/user-attachments/assets/5db75bf0-e028-4e1b-be5b-b85e1c1e68cc)
